### PR TITLE
Added Support for GalacticraftAPI's TabRegistry

### DIFF
--- a/src/main/java/micdoodle8/mods/galacticraft/api/client/tabs/AbstractTab.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/api/client/tabs/AbstractTab.java
@@ -1,0 +1,85 @@
+package micdoodle8.mods.galacticraft.api.client.tabs;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiButton;
+import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.client.gui.inventory.GuiInventory;
+import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.client.renderer.RenderHelper;
+import net.minecraft.client.renderer.RenderItem;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.client.FMLClientHandler;
+
+public abstract class AbstractTab extends GuiButton
+{
+	ResourceLocation texture = new ResourceLocation("textures/gui/container/creative_inventory/tabs.png");
+	ItemStack renderStack;
+	public int potionOffsetLast;
+	protected RenderItem itemRender;
+	
+	public AbstractTab(int id, int posX, int posY, ItemStack renderStack)
+	{
+		super(id, posX, posY, 28, 32, "");
+		this.renderStack = renderStack;
+		this.itemRender = FMLClientHandler.instance().getClient().getRenderItem();
+	}
+	
+	@Override
+	public void drawButton(Minecraft mc, int mouseX, int mouseY, float partialTicks)
+	{
+		int newPotionOffset = TabRegistry.getPotionOffsetNEI();
+		GuiScreen screen = FMLClientHandler.instance().getClient().currentScreen;
+		if (screen instanceof GuiInventory)
+		{
+			newPotionOffset += TabRegistry.getRecipeBookOffset((GuiInventory) screen) - TabRegistry.recipeBookOffset;
+		}
+		if (newPotionOffset != this.potionOffsetLast)
+		{
+			this.x += newPotionOffset - this.potionOffsetLast;
+			this.potionOffsetLast = newPotionOffset;
+		}
+		if (this.visible)
+		{
+			GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
+			
+			int yTexPos = this.enabled ? 3 : 32;
+			int ySize = this.enabled ? 25 : 32;
+			int xOffset = this.id == 2 ? 0 : 1;
+			int yPos = this.y + (this.enabled ? 3 : 0);
+			
+			mc.renderEngine.bindTexture(this.texture);
+			this.drawTexturedModalRect(this.x, yPos, xOffset * 28, yTexPos, 28, ySize);
+			
+			RenderHelper.enableGUIStandardItemLighting();
+			this.zLevel = 100.0F;
+			this.itemRender.zLevel = 100.0F;
+			GlStateManager.enableLighting();
+			GlStateManager.enableRescaleNormal();
+			this.itemRender.renderItemAndEffectIntoGUI(this.renderStack, this.x + 6, this.y + 8);
+			this.itemRender.renderItemOverlayIntoGUI(mc.fontRenderer, this.renderStack, this.x + 6, this.y + 8, null);
+			GlStateManager.disableLighting();
+			GlStateManager.enableBlend();
+			this.itemRender.zLevel = 0.0F;
+			this.zLevel = 0.0F;
+			RenderHelper.disableStandardItemLighting();
+		}
+	}
+	
+	@Override
+	public boolean mousePressed(Minecraft mc, int mouseX, int mouseY)
+	{
+		boolean inWindow = this.enabled && this.visible && mouseX >= this.x && mouseY >= this.y && mouseX < this.x + this.width && mouseY < this.y + this.height;
+		
+		if (inWindow)
+		{
+			this.onTabClicked();
+		}
+		
+		return inWindow;
+	}
+	
+	public abstract void onTabClicked();
+	
+	public abstract boolean shouldAddToList();
+}

--- a/src/main/java/micdoodle8/mods/galacticraft/api/client/tabs/InventoryTabVanilla.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/api/client/tabs/InventoryTabVanilla.java
@@ -1,0 +1,24 @@
+package micdoodle8.mods.galacticraft.api.client.tabs;
+
+import net.minecraft.init.Blocks;
+import net.minecraft.item.ItemStack;
+
+public class InventoryTabVanilla extends AbstractTab
+{
+	public InventoryTabVanilla()
+	{
+		super(0, 0, 0, new ItemStack(Blocks.CRAFTING_TABLE));
+	}
+	
+	@Override
+	public void onTabClicked()
+	{
+		TabRegistry.openInventoryGui();
+	}
+	
+	@Override
+	public boolean shouldAddToList()
+	{
+		return true;
+	}
+}

--- a/src/main/java/micdoodle8/mods/galacticraft/api/client/tabs/TabRegistry.java
+++ b/src/main/java/micdoodle8/mods/galacticraft/api/client/tabs/TabRegistry.java
@@ -1,0 +1,212 @@
+package micdoodle8.mods.galacticraft.api.client.tabs;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.inventory.GuiContainer;
+import net.minecraft.client.gui.inventory.GuiInventory;
+import net.minecraft.inventory.ContainerPlayer;
+import net.minecraft.network.play.client.CPacketCloseWindow;
+import net.minecraft.potion.PotionEffect;
+import net.minecraftforge.client.event.GuiScreenEvent;
+import net.minecraftforge.fml.client.FMLClientHandler;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TabRegistry
+{
+	private static ArrayList<AbstractTab> tabList = new ArrayList<AbstractTab>();
+	private static Class<?> clazzJEIConfig = null;
+	public static Class<?> clazzNEIConfig = null;
+	
+	static
+	{
+		try
+		{
+			//Checks for JEI by looking for this class instead of a Loader.isModLoaded() check
+			clazzJEIConfig = Class.forName("mezz.jei.config.Config");
+		}
+		catch (Exception ignore)
+		{
+			//no log spam
+		}
+		//Only activate NEI feature if NEI is standalone
+		if (clazzJEIConfig == null)
+		{
+			try
+			{
+				clazzNEIConfig = Class.forName("codechicken.nei.NEIClientConfig");
+			}
+			catch (Exception ignore)
+			{
+				//no log spam
+			}
+		}
+	}
+	
+	public static void registerTab(AbstractTab tab)
+	{
+		TabRegistry.tabList.add(tab);
+	}
+	
+	public static ArrayList<AbstractTab> getTabList()
+	{
+		return TabRegistry.tabList;
+	}
+	
+	//Retained for backwards compatibility with TC pre version 1.6.0d40
+	public static void addTabsToInventory (GuiContainer gui)
+	{
+	}
+	
+	@SideOnly(Side.CLIENT)
+	@SubscribeEvent
+	public void guiPostInit (GuiScreenEvent.InitGuiEvent.Post event)
+	{
+		if (event.getGui() instanceof GuiInventory)
+		{
+			int guiLeft = (event.getGui().width - 176) / 2;
+			int guiTop = (event.getGui().height - 166) / 2;
+			recipeBookOffset = getRecipeBookOffset((GuiInventory) event.getGui());
+			guiLeft += getPotionOffset() + recipeBookOffset;
+			
+			TabRegistry.updateTabValues(guiLeft, guiTop, InventoryTabVanilla.class);
+			TabRegistry.addTabsToList(event.getButtonList());
+		}
+	}
+	
+	private static Minecraft mc = FMLClientHandler.instance().getClient();
+	private static boolean initWithPotion;
+	public static int recipeBookOffset;
+	
+	public static void openInventoryGui()
+	{
+		TabRegistry.mc.player.connection.sendPacket(new CPacketCloseWindow(mc.player.openContainer.windowId));
+		GuiInventory inventory = new GuiInventory(TabRegistry.mc.player);
+		TabRegistry.mc.displayGuiScreen(inventory);
+	}
+	
+	public static void updateTabValues(int cornerX, int cornerY, Class<?> selectedButton)
+	{
+		int count = 2;
+		for (int i = 0; i < TabRegistry.tabList.size(); i++)
+		{
+			AbstractTab t = TabRegistry.tabList.get(i);
+			
+			if (t.shouldAddToList())
+			{
+				t.id = count;
+				t.x = cornerX + (count - 2) * 28;
+				t.y = cornerY - 28;
+				t.enabled = !t.getClass().equals(selectedButton);
+				t.potionOffsetLast = getPotionOffsetNEI();
+				count++;
+			}
+		}
+	}
+	
+	public static void addTabsToList(List buttonList)
+	{
+		for (AbstractTab tab : TabRegistry.tabList)
+		{
+			if (tab.shouldAddToList())
+			{
+				buttonList.add(tab);
+			}
+		}
+	}
+	
+	public static int getPotionOffset()
+	{
+/*Disabled in 1.12.2 because a vanilla bug means potion offsets are currently not a thing
+ *The vanilla bug is that GuiInventory.initGui() resets GuiLeft to the recipe book version of GuiLeft,
+ *and in GuiRecipeBook.updateScreenPosition() it takes no account of potion offset even if the recipe book is inactive.
+		// If at least one potion is active...
+		if (doPotionOffsetVanilla())
+		{
+			initWithPotion = true;
+			return 60 + getPotionOffsetJEI() + getPotionOffsetNEI();
+		}
+ */
+		
+		// No potions, no offset needed
+		initWithPotion = false;
+		return 0;
+	}
+	
+	public static boolean doPotionOffsetVanilla()
+	{
+		for (PotionEffect potioneffect : mc.player.getActivePotionEffects())
+		{
+			if (potioneffect.getPotion().shouldRender(potioneffect))
+			{
+				return true;
+			}
+		}
+		return false;
+	}
+	
+	public static int getPotionOffsetJEI()
+	{
+		if (clazzJEIConfig != null)
+		{
+			try
+			{
+				Object enabled = clazzJEIConfig.getMethod("isOverlayEnabled").invoke(null);
+				if (enabled instanceof Boolean)
+				{
+					if (!((Boolean)enabled))
+					{
+						// If JEI is disabled, no special change to getPotionOffset()
+						return 0;
+					}
+					//Active JEI undoes the standard potion offset (they listen for GuiScreenEvent.PotionShiftEvent)
+					return -60;
+				}
+			}
+			catch (Exception ignore)
+			{
+				//no log spam
+			}
+		}
+		return 0;
+	}
+	
+	public static int getPotionOffsetNEI()
+	{
+		if (initWithPotion && clazzNEIConfig != null)
+		{
+			try
+			{
+				// Check whether NEI is hidden and enabled
+				Object hidden = clazzNEIConfig.getMethod("isHidden").invoke(null);
+				Object enabled = clazzNEIConfig.getMethod("isEnabled").invoke(null);
+				if (hidden instanceof Boolean && enabled instanceof Boolean)
+				{
+					if ((Boolean)hidden || !((Boolean)enabled))
+					{
+						// If NEI is disabled or hidden, it does not affect the tabs offset with potions
+						return 0;
+					}
+					//But active NEI undoes the standard potion offset
+					return -60;
+				}
+			}
+			catch (Exception ignore)
+			{
+				//no log spam
+			}
+		}
+		//No NEI, no change
+		return 0;
+	}
+	
+	public static int getRecipeBookOffset(GuiInventory gui)
+	{
+		boolean widthTooNarrow = gui.width < 379;
+		gui.func_194310_f().func_194303_a(gui.width, gui.height, mc, widthTooNarrow, ((ContainerPlayer)gui.inventorySlots).craftMatrix);
+		return gui.func_194310_f().updateScreenPosition(widthTooNarrow, gui.width, gui.xSize) - (gui.width - 176) / 2;
+	}
+}

--- a/src/main/java/techguns/client/ClientProxy.java
+++ b/src/main/java/techguns/client/ClientProxy.java
@@ -7,6 +7,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import micdoodle8.mods.galacticraft.api.client.tabs.InventoryTabVanilla;
+import micdoodle8.mods.galacticraft.api.client.tabs.TabRegistry;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
@@ -272,6 +274,7 @@ import techguns.gui.containers.MetalPressContainer;
 import techguns.gui.containers.ReactionChamberContainer;
 import techguns.gui.containers.RepairBenchContainer;
 import techguns.gui.containers.TurretContainer;
+import techguns.gui.player.InventoryTabTechGuns;
 import techguns.items.guns.GenericGun;
 import techguns.keybind.TGKeybinds;
 import techguns.tileentities.AmmoPressTileEnt;
@@ -418,7 +421,16 @@ public class ClientProxy extends CommonProxy {
 		ClientRegistry.bindTileEntitySpecialRenderer(Door3x3TileEntity.class, new RenderDoor3x3Fast());
 		
 		this.initGuiHandler();
+		
+		if (TabRegistry.getTabList().size() == 0)
+		{
+			TabRegistry.registerTab(new InventoryTabVanilla());
+		}
+		
+		TabRegistry.registerTab(new InventoryTabTechGuns());
 	}
+	
+	
 	
 	protected void initGuiHandler() {
 		guihandler.<CamoBenchTileEnt>addEntry(CamoBenchTileEnt.class, CamoBenchGui::new, CamoBenchContainer::new);

--- a/src/main/java/techguns/events/TGGuiEvents.java
+++ b/src/main/java/techguns/events/TGGuiEvents.java
@@ -197,26 +197,6 @@ public class TGGuiEvents extends Gui{
 		mc.fontRenderer.drawString(text, sr.getScaledWidth()+1-text.length()*6,sr.getScaledHeight()-mc.fontRenderer.FONT_HEIGHT-2+offsetY , 0xFFFFFFFF);
 	}
 	
-	
-	@SideOnly(Side.CLIENT)
-	@SubscribeEvent(priority=EventPriority.NORMAL, receiveCanceled=false)
-	public void onGuiPostInit(GuiScreenEvent.InitGuiEvent.Post event){
-		//System.out.println("Init GUI:"+event.getGui());
-		if (event.getGui() instanceof GuiInventory){
-		    int xSize = 176;
-		    int ySize = 166;
-			
-		    int k = (event.getGui().width - xSize) / 2;
-	        int l = (event.getGui().height - ySize) / 2;
-			
-	        //TODO: get this from config file
-	        int index = 2;
-	        event.getButtonList().add(new TGGuiTabButton(index, k+5, l-26, false,new ItemStack(Blocks.CRAFTING_TABLE,1),0));
-	        event.getButtonList().add(new TGGuiTabButton(index, k+5+28, l-26, true,TGItems.newStack(TGItems.PISTOL_ROUNDS,1),0));
-			
-		}
-	}
-	
 	@SideOnly(Side.CLIENT)
 	@SubscribeEvent(priority=EventPriority.NORMAL, receiveCanceled=false)
 	public void onRenderCrosshairs(RenderGameOverlayEvent event){

--- a/src/main/java/techguns/gui/player/InventoryTabTechGuns.java
+++ b/src/main/java/techguns/gui/player/InventoryTabTechGuns.java
@@ -1,0 +1,31 @@
+package techguns.gui.player;
+
+import micdoodle8.mods.galacticraft.api.client.tabs.AbstractTab;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.inventory.GuiInventory;
+import net.minecraft.client.resources.I18n;
+import net.minecraft.item.ItemStack;
+import net.minecraft.network.play.client.CPacketCloseWindow;
+import techguns.TGItems;
+import techguns.TGPackets;
+import techguns.packets.PacketOpenPlayerGUI;
+
+public class InventoryTabTechGuns extends AbstractTab
+{
+	public InventoryTabTechGuns()
+	{
+		super(0, 0, 0, TGItems.PISTOL_ROUNDS);
+	}
+	
+	@Override
+	public void onTabClicked()
+	{
+		TGPackets.network.sendToServer(new PacketOpenPlayerGUI());
+	}
+	
+	@Override
+	public boolean shouldAddToList()
+	{
+		return true;
+	}
+}

--- a/src/main/java/techguns/gui/player/TGPlayerInventoryGui.java
+++ b/src/main/java/techguns/gui/player/TGPlayerInventoryGui.java
@@ -5,16 +5,15 @@ import java.util.List;
 
 import com.mojang.realmsclient.gui.ChatFormatting;
 
+
+import micdoodle8.mods.galacticraft.api.client.tabs.TabRegistry;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.inventory.GuiInventory;
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.init.Blocks;
 import net.minecraft.inventory.Container;
-import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
-import techguns.TGItems;
 import techguns.Techguns;
 import techguns.api.damagesystem.DamageType;
 import techguns.capabilities.TGExtendedPlayer;
@@ -24,13 +23,12 @@ import techguns.items.armors.GenericArmor;
 
 public class TGPlayerInventoryGui extends TGBaseGui {
 
-
 		public static ResourceLocation texture = new ResourceLocation(Techguns.MODID,"textures/gui/tgplayerinventory.png");
 		private final TGPlayerInventory inventory;
 		private float sizex;
 		private float sizey;
 		private TGExtendedPlayer props;
-		
+	
 		private static final int togglebuttons_xpos= -8;
 		/*public GuiTGPlayerInventory(EntityPlayer player, InventoryPlayer inv, TGPlayerInventory tgplayerinv) {
 			super(new TGPlayerContainer(player, inv, tgplayerinv));
@@ -177,24 +175,19 @@ public class TGPlayerInventoryGui extends TGBaseGui {
 		@Override
 		public void initGui() {
 			super.initGui();
-			int index=0;
 			
-			/*if (!Techguns.isTConstructLoaded){
-				this.buttonList.add(new TGGuiTabButton(index, this.guiLeft-26, this.guiTop+5, true, new ItemStack(Blocks.crafting_table,1),0));
-			    this.buttonList.add(new TGGuiTabButton(index, this.guiLeft-26, this.guiTop+5+26, false,TGItems.newStack(TGItems.bullets9mm,1),TGConfig.GUI_ID_tgplayerInventory));
-			} else {
-				((TechgunsTConstructIntegrationClient)Techguns.pluginTConstructIntegration).addTabs(this.guiLeft, this.guiTop, this.buttonList);
-
-			}*/
-			this.buttonList.add(new TGGuiTabButton(index, this.guiLeft+5, this.guiTop-26, true, new ItemStack(Blocks.CRAFTING_TABLE,1),-1));
-		    this.buttonList.add(new TGGuiTabButton(index, this.guiLeft+5+28, this.guiTop-26, false,TGItems.newStack(TGItems.PISTOL_ROUNDS,1),0));			
+			int index = 0;
 			
+			this.guiLeft = (this.width - this.xSize) / 2;
+			
+			int cornerX = this.guiLeft;
+			int cornerY = this.guiTop;
+			
+			TabRegistry.updateTabValues(cornerX, cornerY, InventoryTabTechGuns.class);
+			TabRegistry.addTabsToList(this.buttonList);
 			
 		    for(int x =0; x<5;x++){
 		    	this.buttonList.add(new TGGuiToggleButton(++index, this.guiLeft+togglebuttons_xpos/*+173*/, this.guiTop+7+(x*11), x));
 		    }
 		}
-
-		
-		
 }


### PR DESCRIPTION
This is in regards to #14 

Added TabRegistry files (distributed for now as is done by CustomNPCs and More Player Models, ideally not)
Added InventoryTabTechGuns and set it to register in Init
Removed TGGuiEvents#onGuiPostInit, no longer needed using the TabRegistry
Updated TGPlayerInventoryGui#initGui to use the TabRegistry buttons

The following gif is taken from 1.12.2 testing

https://gfycat.com/ThickElegantBlesbok