### PR TITLE
Disable Recipes for Ingots and Nuggets when disabled in Config

### DIFF
--- a/src/main/java/techguns/recipes/ConfigConditionFactory.java
+++ b/src/main/java/techguns/recipes/ConfigConditionFactory.java
@@ -1,0 +1,49 @@
+package techguns.recipes;
+
+import com.google.gson.JsonObject;
+import net.minecraft.util.JsonUtils;
+import net.minecraftforge.common.crafting.IConditionFactory;
+import net.minecraftforge.common.crafting.JsonContext;
+import techguns.TGConfig;
+import techguns.Techguns;
+
+import java.util.function.BooleanSupplier;
+
+public class ConfigConditionFactory implements IConditionFactory
+{
+	public static final String INGOT_COPPER= "addCopperIngots";
+	public static final String NUGGET_COPPER= "addCopperNuggets";
+	public static final String INGOT_TIN= "addTinIngots";
+	public static final String INGOT_BRONZE= "addBronzeIngots";
+	public static final String INGOT_LEAD= "addLeadIngots";
+	public static final String NUGGET_LEAD= "addLeadNuggets";
+	public static final String INGOT_STEEL= "addSteelIngots";
+	public static final String NUGGET_STEEL= "addSteelNuggets";
+	
+	@Override
+	public BooleanSupplier parse(JsonContext context, JsonObject json)
+	{
+		boolean value = JsonUtils.getBoolean(json , "value", true);
+		String key = JsonUtils.getString(json, "type");
+		
+		if(key.equals(Techguns.MODID + ":" +INGOT_COPPER)) {
+			return () -> TGConfig.addCopperIngots == value;
+		} else if(key.equals(Techguns.MODID + ":" +NUGGET_COPPER)) {
+			return () -> TGConfig.addCopperNuggets == value;
+		} else if(key.equals(Techguns.MODID + ":" +INGOT_TIN)) {
+			return () -> TGConfig.addTinIngots == value;
+		} else if(key.equals(Techguns.MODID + ":" +INGOT_BRONZE)) {
+			return () -> TGConfig.addBronzeIngots == value;
+		} else if(key.equals(Techguns.MODID + ":" +INGOT_LEAD)) {
+			return () -> TGConfig.addLeadIngots == value;
+		} else if(key.equals(Techguns.MODID + ":" +NUGGET_LEAD)) {
+			return () -> TGConfig.addLeadNuggets == value;
+		} else if(key.equals(Techguns.MODID + ":" +INGOT_STEEL)) {
+			return () -> TGConfig.addSteelIngots == value;
+		} else if(key.equals(Techguns.MODID + ":" +NUGGET_STEEL)) {
+			return () -> TGConfig.addSteelNuggets == value;
+		}
+		
+		return null;
+	}
+}

--- a/src/main/java/techguns/recipes/Recipewriter.java
+++ b/src/main/java/techguns/recipes/Recipewriter.java
@@ -313,13 +313,13 @@ public class Recipewriter {
         RecipeJsonConverter.addShapedRecipe(TGItems.newStack(TGItems.RC_HEAT_RAY,1), "cwc","plp","plp", 'c', "circuitElite", 'w', "wireGold", 'p', "plateSteel", 'l', Blocks.REDSTONE_LAMP);
 	
         //ingots/nugget
-        RecipeJsonConverter.addShapelessRecipe(TGItems.INGOT_COPPER, "nuggetCopper","nuggetCopper","nuggetCopper","nuggetCopper","nuggetCopper","nuggetCopper","nuggetCopper","nuggetCopper","nuggetCopper");
-        RecipeJsonConverter.addShapelessRecipe(TGItems.INGOT_LEAD, "nuggetLead","nuggetLead","nuggetLead","nuggetLead","nuggetLead","nuggetLead","nuggetLead","nuggetLead","nuggetLead");
-        RecipeJsonConverter.addShapelessRecipe(TGItems.INGOT_STEEL, "nuggetSteel","nuggetSteel","nuggetSteel","nuggetSteel","nuggetSteel","nuggetSteel","nuggetSteel","nuggetSteel","nuggetSteel");
+        RecipeJsonConverter.addConditionedShapelessRecipe(TGItems.INGOT_COPPER, ConfigConditionFactory.INGOT_COPPER,"nuggetCopper","nuggetCopper","nuggetCopper","nuggetCopper","nuggetCopper","nuggetCopper","nuggetCopper","nuggetCopper","nuggetCopper");
+        RecipeJsonConverter.addConditionedShapelessRecipe(TGItems.INGOT_LEAD, ConfigConditionFactory.INGOT_LEAD,"nuggetLead","nuggetLead","nuggetLead","nuggetLead","nuggetLead","nuggetLead","nuggetLead","nuggetLead","nuggetLead");
+        RecipeJsonConverter.addConditionedShapelessRecipe(TGItems.INGOT_STEEL, ConfigConditionFactory.INGOT_STEEL,"nuggetSteel","nuggetSteel","nuggetSteel","nuggetSteel","nuggetSteel","nuggetSteel","nuggetSteel","nuggetSteel","nuggetSteel");
         
-        RecipeJsonConverter.addShapelessRecipe(TGItems.newStack(TGItems.NUGGET_COPPER, 9), "ingotCopper");
-        RecipeJsonConverter.addShapelessRecipe(TGItems.newStack(TGItems.NUGGET_LEAD, 9), "ingotLead");
-        RecipeJsonConverter.addShapelessRecipe(TGItems.newStack(TGItems.NUGGET_STEEL, 9), "ingotSteel");
+        RecipeJsonConverter.addConditionedShapelessRecipe(TGItems.newStack(TGItems.NUGGET_COPPER, 9),ConfigConditionFactory.NUGGET_COPPER, "ingotCopper");
+        RecipeJsonConverter.addConditionedShapelessRecipe(TGItems.newStack(TGItems.NUGGET_LEAD, 9), ConfigConditionFactory.NUGGET_LEAD, "ingotLead");
+        RecipeJsonConverter.addConditionedShapelessRecipe(TGItems.newStack(TGItems.NUGGET_STEEL, 9), ConfigConditionFactory.NUGGET_STEEL, "ingotSteel");
         
         ItemStack rc = new ItemStack(TGBlocks.MULTIBLOCK_MACHINE,1, EnumMultiBlockMachineType.REACTIONCHAMBER_HOUSING.getIndex());
         RecipeJsonConverter.addShapedRecipe(new ItemStack(TGBlocks.MULTIBLOCK_MACHINE,9,EnumMultiBlockMachineType.REACTIONCHAMBER_HOUSING.getIndex()), "sms","pcp","ses", 's', "plateSteel", 'm', MECHANICAL_PARTS_CARBON, 'p', TGItems.CYBERNETIC_PARTS, 'e', "circuitElite",'c', new ItemStack(TGBlocks.BASIC_MACHINE,1, EnumMachineType.CHEM_LAB.getIndex()));


### PR DESCRIPTION
This is a small change to allow certain recipes to be disabled based on their config status. As Techguns uses generated recipes, rather than edit files that will be overwritten, I've changed the existing Recipewrite and RecipeJsonConverter classes themselves to ensure generated .json files have the proper conditions added.

- Added ConfigConditionFactory to allow Recipes to be disabled based on Config settings.
- Added 'addConditionedShapelessRecipe' to RecipeJsonConverter that adds the passed predefined condition to the generated recipe file.
- Changed Recipewriter to use addConditionedShapelessRecipe for Ingot and Nugget Recipes. This ensures that when those items are disabled in the config that the recipes themselves do not load.