### PR TITLE
Fix integration with Albedo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,7 +80,7 @@ dependencies {
     // http://www.gradle.org/docs/current/userguide/dependency_management.html
 
 	//compile 'elucent:albedo:2.0-SNAPSHOT'
-	deobfCompile 'albedo:albedo:0.1.3:deobf'
+	compile 'albedo:albedo:1.12.2:1.1.0'
 	
 	compile 'crafttweaker:CraftTweaker2:1.12:4.1.13'
 	

--- a/src/main/java/techguns/entities/projectiles/AlienBlasterProjectile.java
+++ b/src/main/java/techguns/entities/projectiles/AlienBlasterProjectile.java
@@ -1,9 +1,11 @@
 package techguns.entities.projectiles;
 
+import elucent.albedo.event.GatherLightsEvent;
 import elucent.albedo.lighting.ILightProvider;
 import elucent.albedo.lighting.Light;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.world.World;
@@ -93,6 +95,7 @@ public class AlienBlasterProjectile extends GenericProjectile implements ILightP
 		
 	}
 
+	@Optional.Method(modid="albedo")
 	@Override
 	public Light provideLight() {
 		return Light.builder()
@@ -100,6 +103,13 @@ public class AlienBlasterProjectile extends GenericProjectile implements ILightP
 				.color(TGuns.alienblaster.light_r,TGuns.alienblaster.light_g,TGuns.alienblaster.light_b)
 				.radius(4)
 				.build();
+	}
+
+	@Optional.Method(modid="albedo")
+	@Override
+	public void gatherLights(GatherLightsEvent arg0, Entity arg1) {
+		// TODO Auto-generated method stub
+		
 	}
 	
 	

--- a/src/main/java/techguns/entities/projectiles/FlamethrowerProjectile.java
+++ b/src/main/java/techguns/entities/projectiles/FlamethrowerProjectile.java
@@ -1,7 +1,9 @@
 package techguns.entities.projectiles;
 
+import elucent.albedo.event.GatherLightsEvent;
 import elucent.albedo.lighting.ILightProvider;
 import elucent.albedo.lighting.Light;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.util.EnumParticleTypes;
 import net.minecraft.util.math.RayTraceResult;
@@ -126,5 +128,12 @@ public class FlamethrowerProjectile extends GenericProjectile implements ILightP
 				.color(1.0f, 0.8f, 0f)
 				.radius(2.5f)
 				.build();
+	}
+
+	@Optional.Method(modid="albedo")
+	@Override
+	public void gatherLights(GatherLightsEvent arg0, Entity arg1) {
+		// TODO Auto-generated method stub
+		
 	}
 }

--- a/src/main/java/techguns/entities/projectiles/GaussProjectile.java
+++ b/src/main/java/techguns/entities/projectiles/GaussProjectile.java
@@ -1,10 +1,12 @@
 package techguns.entities.projectiles;
 
+import elucent.albedo.event.GatherLightsEvent;
 import elucent.albedo.lighting.ILightProvider;
 import elucent.albedo.lighting.Light;
 import io.netty.buffer.ByteBuf;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.SoundCategory;
@@ -147,5 +149,12 @@ public class GaussProjectile extends AdvancedBulletProjectile implements ILightP
 				.color(0.5f,0.75f, 1f)
 				.radius(2.5f)
 				.build();
+	}
+
+	@Optional.Method(modid="albedo")
+	@Override
+	public void gatherLights(GatherLightsEvent arg0, Entity arg1) {
+		// TODO Auto-generated method stub
+		
 	}
 }

--- a/src/main/java/techguns/entities/projectiles/RocketProjectile.java
+++ b/src/main/java/techguns/entities/projectiles/RocketProjectile.java
@@ -1,7 +1,9 @@
 package techguns.entities.projectiles;
 
+import elucent.albedo.event.GatherLightsEvent;
 import elucent.albedo.lighting.ILightProvider;
 import elucent.albedo.lighting.Light;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.world.World;
@@ -108,6 +110,13 @@ public class RocketProjectile extends GenericProjectile implements ILightProvide
 				.color(1f,1f, 1f)
 				.radius(3)
 				.build();
+	}
+
+	@Optional.Method(modid="albedo")
+	@Override
+	public void gatherLights(GatherLightsEvent arg0, Entity arg1) {
+		// TODO Auto-generated method stub
+		
 	}
 
 }

--- a/src/main/java/techguns/entities/projectiles/TFGProjectile.java
+++ b/src/main/java/techguns/entities/projectiles/TFGProjectile.java
@@ -1,8 +1,10 @@
 package techguns.entities.projectiles;
 
+import elucent.albedo.event.GatherLightsEvent;
 import elucent.albedo.lighting.ILightProvider;
 import elucent.albedo.lighting.Light;
 import io.netty.buffer.ByteBuf;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.world.World;
@@ -140,5 +142,12 @@ public class TFGProjectile extends GenericProjectile implements IEntityAdditiona
 				.color(0.5f,1.0f, 0.5f)
 				.radius(2f+(size*0.5f))
 				.build();
+	}
+
+	@Optional.Method(modid="albedo")
+	@Override
+	public void gatherLights(GatherLightsEvent arg0, Entity arg1) {
+		// TODO Auto-generated method stub
+		
 	}
 }

--- a/src/main/java/techguns/events/TGEventHandler.java
+++ b/src/main/java/techguns/events/TGEventHandler.java
@@ -835,7 +835,7 @@ public class TGEventHandler {
 	public static void onGatherLightsEvent(GatherLightsEvent event) {
 		ClientProxy cp = ClientProxy.get();
 		for (int i=0;i<cp.activeLightPulses.size();i++) {
-			event.getLightList().add(cp.activeLightPulses.get(i).provideLight());
+			event.add(cp.activeLightPulses.get(i).provideLight());
 		}
 		//ClientProxy.get().activeLightPulses.forEach(l -> event.getLightList().add(l.provideLight()));
 	}


### PR DESCRIPTION
When firing a weapon which should light up the surroundings, the game crashes if you have a newer version of Albedo.
It is because before you expect to get an ArrayList and add the lights to it, now it is a ImmutableList.
The solution is to switch to use the events own add method to add the lights.
This is what I have done together with implementing the interface on the projectile classes.