### PR TITLE
added OpenComputers support to reaction chamber

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,10 @@ repositories {
 		name="Latmods"
 		url "https://maven.latmod.com/"
 	}
+	maven {
+		name = "OpenComputers"
+		url = "http://maven.cil.li/"
+	}
 }
 dependencies {
     // you may put jars on which you depend on in ./libs
@@ -96,6 +100,8 @@ dependencies {
 	deobfProvided "mezz.jei:jei_${mc_version}:${jei_version}:api"
 	// at runtime, use the full JEI jar
 	runtime "mezz.jei:jei_${mc_version}:${jei_version}"
+	
+	deobfCompile "li.cil.oc:OpenComputers:${openComputersVersion}"
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,3 +3,5 @@
 org.gradle.jvmargs=-Xmx3G
 mc_version=1.12.2
 jei_version=4.13.1.225
+
+openComputersVersion = MC1.12.2-1.7.+

--- a/src/main/java/techguns/api/capabilities/ITGExtendedPlayer.java
+++ b/src/main/java/techguns/api/capabilities/ITGExtendedPlayer.java
@@ -1,9 +1,9 @@
 package techguns.api.capabilities;
 
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.inventory.IInventory;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumHand;
+import net.minecraftforge.items.ItemStackHandler;
 
 /**
  * Should only be used on EntityPlayer
@@ -15,7 +15,7 @@ public interface ITGExtendedPlayer extends ITGShooterValues {
 	
 	public int getFireDelay(EnumHand hand);
 	public void setFireDelay(EnumHand hand, int delay);
-	public IInventory getTGInventory();
+	public ItemStackHandler getTGInventory();
 	
 	public void saveToNBT(final NBTTagCompound tags);
 	public void loadFromNBT(final NBTTagCompound tags);

--- a/src/main/java/techguns/api/tginventory/ITGSpecialSlot.java
+++ b/src/main/java/techguns/api/tginventory/ITGSpecialSlot.java
@@ -21,6 +21,21 @@ public interface ITGSpecialSlot {
 	public default void onPlayerTick(ItemStack item, PlayerTickEvent player) {};
 
 	/**
+	 * Called when an item gets equipped
+	 * @param item
+	 * @param player
+	 */
+	public default void onEquipped(ItemStack item, EntityPlayer player) {};
+
+	/**
+	 * Called when an item gets unequipped
+	 * @param item
+	 * @param player
+	 */
+	public default void onUnequipped(ItemStack item, EntityPlayer player) {};
+
+
+	/**
 	 * @param type The bonus type
 	 * @param stack
 	 * @param consume if power should be consumed (the bonus is actively used)
@@ -30,4 +45,6 @@ public interface ITGSpecialSlot {
 	public default float getBonus(TGArmorBonus type, ItemStack stack, boolean consume, EntityPlayer player) {
 		return 0f;
 	}
+
+
 }

--- a/src/main/java/techguns/api/tginventory/ITGSpecialSlot.java
+++ b/src/main/java/techguns/api/tginventory/ITGSpecialSlot.java
@@ -21,19 +21,29 @@ public interface ITGSpecialSlot {
 	public default void onPlayerTick(ItemStack item, PlayerTickEvent player) {};
 
 	/**
-	 * Called when an item gets equipped
-	 * @param item
+	 * Called when the item gets equipped
+	 * this compares only the item! if you swap the item for one with different NBT it wont get called, use onSlotChanged() to detect swapping of unique items
+	 * @param stack
 	 * @param player
 	 */
-	public default void onEquipped(ItemStack item, EntityPlayer player) {};
+	public default void onEquipped(ItemStack stack, EntityPlayer player) {};
 
 	/**
-	 * Called when an item gets unequipped
-	 * @param item
+	 * Called when the item gets unequipped
+	 * this compares only the item! if you swap the item for one with different NBT it wont get called, use onSlotChanged() to detect swapping of unique items
+	 * @param stack
 	 * @param player
 	 */
-	public default void onUnequipped(ItemStack item, EntityPlayer player) {};
+	public default void onUnequipped(ItemStack stack, EntityPlayer player) {};
 
+	/**
+	 * Called when the item slot changes (equipped/unequipped/updated)
+	 * gets called for both stacks. oldStack and newStack might be the same itemStack
+	 * @param oldStack
+	 * @param newStack
+	 * @param player
+	 */
+	public default void onSlotChanged(ItemStack oldStack, ItemStack newStack, EntityPlayer player) {};
 
 	/**
 	 * @param type The bonus type

--- a/src/main/java/techguns/client/render/AdditionalSlotRenderRegistry.java
+++ b/src/main/java/techguns/client/render/AdditionalSlotRenderRegistry.java
@@ -6,7 +6,7 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 
 public class AdditionalSlotRenderRegistry {
-	protected static final HashMap<Item,RenderAdditionalSlotItem> registry = new HashMap<>();
+	protected static final HashMap<Item, RenderAdditionalSlotItem> registry = new HashMap<>();
 	
 	public static void register(Item item, RenderAdditionalSlotItem render) {
 		registry.put(item, render);

--- a/src/main/java/techguns/client/render/entities/TGLayerRendererer.java
+++ b/src/main/java/techguns/client/render/entities/TGLayerRendererer.java
@@ -25,13 +25,13 @@ public class TGLayerRendererer implements LayerRenderer<EntityPlayer>{
 		TGExtendedPlayer props = TGExtendedPlayer.get(player);
 		
 		if(isSlotVisible(TGPlayerInventory.SLOT_FACE,player)) {
-			this.renderSlot(props.tg_inventory.inventory.get(TGPlayerInventory.SLOT_FACE), player, limbSwing, limbSwingAmount, partialTicks, ageInTicks, netHeadYaw, headPitch, scale);
+			this.renderSlot(props.tg_inventory.getStackInSlot(TGPlayerInventory.SLOT_FACE), player, limbSwing, limbSwingAmount, partialTicks, ageInTicks, netHeadYaw, headPitch, scale);
 		}
 		if(isSlotVisible(TGPlayerInventory.SLOT_BACK,player)) {
-			this.renderSlot(props.tg_inventory.inventory.get(TGPlayerInventory.SLOT_BACK), player, limbSwing, limbSwingAmount, partialTicks, ageInTicks, netHeadYaw, headPitch, scale);
+			this.renderSlot(props.tg_inventory.getStackInSlot(TGPlayerInventory.SLOT_BACK), player, limbSwing, limbSwingAmount, partialTicks, ageInTicks, netHeadYaw, headPitch, scale);
 		}
 		if(isSlotVisible(TGPlayerInventory.SLOT_HAND,player)) {
-			this.renderSlot(props.tg_inventory.inventory.get(TGPlayerInventory.SLOT_HAND), player, limbSwing, limbSwingAmount, partialTicks, ageInTicks, netHeadYaw, headPitch, scale);
+			this.renderSlot(props.tg_inventory.getStackInSlot(TGPlayerInventory.SLOT_HAND), player, limbSwing, limbSwingAmount, partialTicks, ageInTicks, netHeadYaw, headPitch, scale);
 		}
 	}
 

--- a/src/main/java/techguns/client/render/entities/npcs/RenderAttackHelicopter.java
+++ b/src/main/java/techguns/client/render/entities/npcs/RenderAttackHelicopter.java
@@ -3,6 +3,8 @@ package techguns.client.render.entities.npcs;
 import java.io.IOException;
 import java.util.List;
 
+import net.minecraftforge.client.model.Attributes;
+import net.minecraftforge.client.model.pipeline.LightUtil;
 import org.lwjgl.opengl.GL11;
 
 import net.minecraft.client.Minecraft;
@@ -19,14 +21,9 @@ import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.client.renderer.texture.PngSizeInfo;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
-import net.minecraft.init.Blocks;
-import net.minecraft.util.EnumFacing;
 import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.math.BlockPos;
 import net.minecraftforge.client.model.IModel;
 import net.minecraftforge.client.model.ModelLoaderRegistry;
-import net.minecraftforge.client.model.pipeline.VertexBufferConsumer;
-import net.minecraftforge.client.model.pipeline.VertexLighterFlat;
 import net.minecraftforge.common.model.TRSRTransformation;
 import techguns.Techguns;
 import techguns.entities.npcs.AttackHelicopter;
@@ -41,7 +38,7 @@ public class RenderAttackHelicopter extends RenderLiving<AttackHelicopter> {
 	private static IBakedModel helicopter_main;
 	private static IBakedModel helicopter_rotor;
 	private static IBakedModel helicopter_gun;
-	private final VertexLighterFlat lighter = new VertexLighterFlat(Minecraft.getMinecraft().getBlockColors());
+
 	public static void initModels() {
 		helicopter_main = loadAndBakedModel(modelLoc0, texture);
 		helicopter_rotor = loadAndBakedModel(modelLoc1, texture);
@@ -76,10 +73,7 @@ public class RenderAttackHelicopter extends RenderLiving<AttackHelicopter> {
 
 	@Override
 	public void doRender(AttackHelicopter entity, double x, double y, double z, float entityYaw, float partialTicks) {
-		
-		BlockPos pos = new BlockPos(entity.posX, entity.posY + entity.height, entity.posZ);
-
-        RenderHelper.disableStandardItemLighting();
+		RenderHelper.disableStandardItemLighting();
         GlStateManager.pushMatrix();
         
         GlStateManager.translate((float)x, (float)y, (float)z);
@@ -94,11 +88,7 @@ public class RenderAttackHelicopter extends RenderLiving<AttackHelicopter> {
         
         Tessellator tessellator = Tessellator.getInstance();
         BufferBuilder builder = tessellator.getBuffer();
-        
-        lighter.setWorld(entity.world);
-        lighter.setState(Blocks.AIR.getDefaultState());
-        lighter.setBlockPos(pos);
-        
+
         if (entity.deathTime==0) {
 	        renderBakedModel(tessellator, builder, helicopter_main);
 	        
@@ -129,7 +119,8 @@ public class RenderAttackHelicopter extends RenderLiving<AttackHelicopter> {
         	
 	         renderBakedModel(tessellator, builder, helicopter_main);
 	         renderBakedModel(tessellator, builder, helicopter_gun);
-	         
+
+
 	         angle = ((float)((Minecraft.getMinecraft().world.getTotalWorldTime() % 60)+partialTicks) * 12.0f);
 	         GlStateManager.rotate(angle, 0, 1f, 0);
 	         renderBakedModel(tessellator, builder, helicopter_rotor);
@@ -139,35 +130,14 @@ public class RenderAttackHelicopter extends RenderLiving<AttackHelicopter> {
         RenderHelper.enableStandardItemLighting();
 	}
 
-	protected void renderBakedModel(Tessellator tessellator, BufferBuilder builder, IBakedModel bakedModel) {
+	private void renderBakedModel(Tessellator tessellator, BufferBuilder buffer, IBakedModel model){
+		buffer.begin(GL11.GL_QUADS, Attributes.DEFAULT_BAKED_FORMAT);
+		for (BakedQuad bakedQuad : model.getQuads(null, null, 0))
+			LightUtil.renderQuadColor(buffer, bakedQuad, -1);
 
-		builder.begin(GL11.GL_QUADS, DefaultVertexFormats.BLOCK);
-		lighter.setParent(new VertexBufferConsumer(builder));
-
-		boolean empty = true;
-		List<BakedQuad> quads = bakedModel.getQuads(null, null, 0);
-		if (!quads.isEmpty()) {
-			lighter.updateBlockInfo();
-			empty = false;
-			for (BakedQuad quad : quads) {
-				quad.pipe(lighter);
-			}
-		}
-		for (EnumFacing side : EnumFacing.values()) {
-			quads = bakedModel.getQuads(null, side, 0);
-			if (!quads.isEmpty()) {
-				if (empty)
-					lighter.updateBlockInfo();
-				empty = false;
-				for (BakedQuad quad : quads) {
-					quad.pipe(lighter);
-				}
-			}
-		}
-
-		builder.setTranslation(0, 0, 0);
 		tessellator.draw();
 	}
+
 	
 	public float interp(float val, float prev_value, float ptt) {
 		return prev_value+ (val-prev_value)*ptt;

--- a/src/main/java/techguns/events/TGGuiEvents.java
+++ b/src/main/java/techguns/events/TGGuiEvents.java
@@ -106,7 +106,7 @@ public class TGGuiEvents extends Gui{
 				
 				ItemStack ammoitem  = pwrchest.getBattery();
 				int count = InventoryUtil.countItemInInv(ply.inventory.mainInventory, ammoitem, 0, ply.inventory.mainInventory.size());
-				count += InventoryUtil.countItemInInv(props.tg_inventory.inventory, ammoitem, TGPlayerInventory.SLOTS_AMMO_START, TGPlayerInventory.SLOTS_AMMO_END+1);
+				count += InventoryUtil.countItemInInv(props.tg_inventory, ammoitem, TGPlayerInventory.SLOTS_AMMO_START, TGPlayerInventory.SLOTS_AMMO_END+1);
 				
 				String text = ChatFormatting.YELLOW+""+count+"x"+ChatFormatting.WHITE+(int)(percent*100)+"%";
 				mc.fontRenderer.drawString(text, sr.getScaledWidth()-2-text.length()*6-8+24, offsetY, 0xFFFFFFFF);
@@ -115,7 +115,7 @@ public class TGGuiEvents extends Gui{
 				
 			}
 			
-			ItemStack backslot = props.tg_inventory.inventory.get(props.tg_inventory.SLOT_BACK);
+			ItemStack backslot = props.tg_inventory.getStackInSlot(props.tg_inventory.SLOT_BACK);
 			if (backslot !=null){
 				
 				//TODO: unhardcode this
@@ -133,7 +133,7 @@ public class TGGuiEvents extends Gui{
 					
 					ItemStack ammoitem  = ((ItemTGSpecialSlotAmmo)backslot.getItem()).getAmmo();
 					int count = InventoryUtil.countItemInInv(ply.inventory.mainInventory, ammoitem, 0, ply.inventory.mainInventory.size());
-					count += InventoryUtil.countItemInInv(props.tg_inventory.inventory, ammoitem, TGPlayerInventory.SLOTS_AMMO_START, TGPlayerInventory.SLOTS_AMMO_END+1);
+					count += InventoryUtil.countItemInInv(props.tg_inventory, ammoitem, TGPlayerInventory.SLOTS_AMMO_START, TGPlayerInventory.SLOTS_AMMO_END+1);
 					
 					String text = ChatFormatting.YELLOW+""+count+"x"+ChatFormatting.WHITE+(int)(percent*100)+"%";
 				
@@ -216,7 +216,7 @@ public class TGGuiEvents extends Gui{
 	
 	private int getAmmoCountOfStack(ItemStack ammoitem, GenericGun gun, EntityPlayer ply, TGExtendedPlayer props) {
 		int count = InventoryUtil.countItemInInv(ply.inventory.mainInventory, ammoitem, 0, ply.inventory.mainInventory.size());
-		count += InventoryUtil.countItemInInv(props.tg_inventory.inventory, ammoitem, TGPlayerInventory.SLOTS_AMMO_START, TGPlayerInventory.SLOTS_AMMO_END+1);
+		count += InventoryUtil.countItemInInv(props.tg_inventory, ammoitem, TGPlayerInventory.SLOTS_AMMO_START, TGPlayerInventory.SLOTS_AMMO_END+1);
 		
 		if (gun.getAmmoCount()>1){
 			count = count / gun.getAmmoCount();

--- a/src/main/java/techguns/events/TGTickHandler.java
+++ b/src/main/java/techguns/events/TGTickHandler.java
@@ -32,7 +32,6 @@ import net.minecraftforge.fml.common.gameevent.TickEvent.ClientTickEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent.Phase;
 import net.minecraftforge.fml.common.gameevent.TickEvent.PlayerTickEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent.RenderTickEvent;
-import net.minecraftforge.fml.relauncher.ReflectionHelper;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import techguns.TGConfig;
@@ -158,9 +157,6 @@ public class TGTickHandler {
 				}
 			}
 
-		} else {
-			
-			
 		}
 
 	}
@@ -168,46 +164,43 @@ public class TGTickHandler {
 	@SubscribeEvent
 	public static void onPlayerTick(PlayerTickEvent event) {
 		TGExtendedPlayer props = TGExtendedPlayer.get(event.player);
-		 
-		 //System.out.println(event.phase);
-		 if (event.phase == Phase.START){
-			
+
+		 if (event.phase.equals(Phase.START)){
 			 //reduce fire delays on both sides
-			 if(props.fireDelayMainhand>0){
+			 if(props.fireDelayMainhand > 0){
 				 props.fireDelayMainhand--;
 			 }
-			 if(props.loopSoundDelayMainhand>0){
+			 if(props.loopSoundDelayMainhand > 0){
 				 props.loopSoundDelayMainhand--;
 			 }
-			 if(props.fireDelayOffhand>0){
+			 if(props.fireDelayOffhand > 0){
 				 props.fireDelayOffhand--;
 			 }
-			 if(props.loopSoundDelayOffhand>0){
+			 if(props.loopSoundDelayOffhand > 0){
 				 props.loopSoundDelayOffhand--;
 			 }
 			 
-			 if (event.side ==Side.SERVER){
+			 if (event.side.equals(Side.SERVER)){
 				 //SERVER ONLY CODE
 				 if (props.swingSoundDelay>0){
 					 props.swingSoundDelay--;
 				 }
 			 }
-			 
-			 
-		 } else if (event.phase == Phase.END){
+		 }
+		 else if (event.phase == Phase.END){
 		 
 		 	 if(!event.player.world.isRemote) {	 
 				 event.player.getDataManager().set(TGExtendedPlayer.DATA_FACE_SLOT, props.tg_inventory.getStackInSlot(TGPlayerInventory.SLOT_FACE));
 				 event.player.getDataManager().set(TGExtendedPlayer.DATA_BACK_SLOT, props.tg_inventory.getStackInSlot(TGPlayerInventory.SLOT_BACK));
 				 event.player.getDataManager().set(TGExtendedPlayer.DATA_HAND_SLOT, props.tg_inventory.getStackInSlot(TGPlayerInventory.SLOT_HAND));
 			 } else {
-				props.tg_inventory.setInventorySlotContents(TGPlayerInventory.SLOT_FACE, event.player.getDataManager().get(TGExtendedPlayer.DATA_FACE_SLOT));
-				props.tg_inventory.setInventorySlotContents(TGPlayerInventory.SLOT_BACK, event.player.getDataManager().get(TGExtendedPlayer.DATA_BACK_SLOT));
-				props.tg_inventory.setInventorySlotContents(TGPlayerInventory.SLOT_HAND, event.player.getDataManager().get(TGExtendedPlayer.DATA_HAND_SLOT));
+				props.tg_inventory.setStackInSlot(TGPlayerInventory.SLOT_FACE, event.player.getDataManager().get(TGExtendedPlayer.DATA_FACE_SLOT));
+				props.tg_inventory.setStackInSlot(TGPlayerInventory.SLOT_BACK, event.player.getDataManager().get(TGExtendedPlayer.DATA_BACK_SLOT));
+				props.tg_inventory.setStackInSlot(TGPlayerInventory.SLOT_HAND, event.player.getDataManager().get(TGExtendedPlayer.DATA_HAND_SLOT));
 			 }
 			 
 			 boolean wearingTechgunsArmor = false;
-			 for (int i =0;i<4;i++){
+			 for (int i=0; i < 4; i++){
 				 ItemStack istack = event.player.inventory.armorInventory.get(i);
 				 if (GenericArmor.isTechgunArmor(istack)){
 					 wearingTechgunsArmor = true;
@@ -402,7 +395,7 @@ public class TGTickHandler {
 							 TGPackets.network.sendTo(new PacketTGExtendedPlayerSync(event.player,props,true), (EntityPlayerMP) event.player);
 						 }
 					 } else {
-						 ItemStack stack = InventoryUtil.consumeFood(props.tg_inventory.inventory, props.tg_inventory.SLOTS_AUTOFOOD_START, props.tg_inventory.SLOTS_AUTOFOOD_END+1);
+						 ItemStack stack = InventoryUtil.consumeFood(props.tg_inventory, props.tg_inventory.SLOTS_AUTOFOOD_START, props.tg_inventory.SLOTS_AUTOFOOD_END+1);
 						 if (!stack.isEmpty()){
 							 ItemFood food = (ItemFood) stack.getItem();
 							 
@@ -457,9 +450,9 @@ public class TGTickHandler {
 			  */
 			 props.isGliding=false;
 			 
-			 tickSlot(props.tg_inventory.inventory.get(TGPlayerInventory.SLOT_FACE), event);
-			 tickSlot(props.tg_inventory.inventory.get(TGPlayerInventory.SLOT_BACK), event);
-			 tickSlot(props.tg_inventory.inventory.get(TGPlayerInventory.SLOT_HAND), event);
+			 tickSlot(props.tg_inventory.getStackInSlot(TGPlayerInventory.SLOT_FACE), event);
+			 tickSlot(props.tg_inventory.getStackInSlot(TGPlayerInventory.SLOT_BACK), event);
+			 tickSlot(props.tg_inventory.getStackInSlot(TGPlayerInventory.SLOT_HAND), event);
 			 
 			 Techguns.proxy.handlePlayerGliding(event.player);
 			 			 
@@ -555,6 +548,8 @@ public class TGTickHandler {
 			 }
 		 }
 	}
+
+
 	
 	protected static void tickSlot(ItemStack slot, PlayerTickEvent event) {
 		if (!slot.isEmpty() && slot.getItem() instanceof ITGSpecialSlot) {

--- a/src/main/java/techguns/gui/CamoBenchGui.java
+++ b/src/main/java/techguns/gui/CamoBenchGui.java
@@ -159,7 +159,7 @@ public class CamoBenchGui extends OwnedTileEntGui {
 		TGExtendedPlayer props = TGExtendedPlayer.get(ply);
 		if (props !=null){
 		
-			ItemStack item = props.tg_inventory.inventory.get(slot);
+			ItemStack item = props.tg_inventory.getStackInSlot(slot);
 			
 			if(!item.isEmpty() && item.getItem() instanceof ICamoChangeable){
 				ICamoChangeable camoItem = (ICamoChangeable) item.getItem();

--- a/src/main/java/techguns/gui/player/TGPlayerInventory.java
+++ b/src/main/java/techguns/gui/player/TGPlayerInventory.java
@@ -40,10 +40,21 @@ public class TGPlayerInventory extends ItemStackHandler {
 		if(oldStack.equals(newStack))
 			return;
 
-		if(newStack.isEmpty() && !oldStack.isEmpty() && oldStack.getItem() instanceof ITGSpecialSlot)
-			((ITGSpecialSlot) oldStack.getItem()).onUnequipped(oldStack, player);
-		else if(oldStack.isEmpty() && !newStack.isEmpty() && newStack.getItem() instanceof ITGSpecialSlot)
-			((ITGSpecialSlot) newStack.getItem()).onEquipped(newStack, player);
+
+		if(newStack.getItem() instanceof ITGSpecialSlot) {
+			((ITGSpecialSlot) newStack.getItem()).onSlotChanged(oldStack, newStack, player);
+
+			if(!ItemStack.areItemsEqual(oldStack, newStack))
+				((ITGSpecialSlot) newStack.getItem()).onEquipped(newStack, player);
+		}
+
+		if(oldStack.getItem() instanceof ITGSpecialSlot) {
+			((ITGSpecialSlot) oldStack.getItem()).onSlotChanged(oldStack, newStack, player);
+
+			if(!ItemStack.areItemsEqual(oldStack, newStack))
+				((ITGSpecialSlot) oldStack.getItem()).onUnequipped(oldStack, player);
+		}
+
 
 		switch(slotid){
 			case SLOT_FACE:

--- a/src/main/java/techguns/gui/player/TGPlayerInventoryOld.java
+++ b/src/main/java/techguns/gui/player/TGPlayerInventoryOld.java
@@ -1,0 +1,176 @@
+package techguns.gui.player;
+
+
+import java.util.List;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.inventory.ItemStackHelper;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.NonNullList;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.TextComponentTranslation;
+import techguns.capabilities.TGExtendedPlayer;
+
+public class TGPlayerInventoryOld implements IInventory {
+    private static final String name = "TechgunsPlayerInventory";
+
+    public static final int NUMSLOTS = 15;
+
+    public static final int SLOT_FACE = 0;
+    public static final int SLOT_BACK = 1;
+    public static final int SLOT_HAND = 2;
+    public static final int SLOTS_AUTOFOOD_START = 3;
+    public static final int SLOTS_AUTOFOOD_END = 5;
+    public static final int SLOT_AUTOHEAL = 6;
+    public static final int SLOTS_AMMO_START = 7;
+    public static final int SLOTS_AMMO_END = 14;
+
+    public NonNullList<ItemStack> inventory = NonNullList.<ItemStack>withSize(NUMSLOTS, ItemStack.EMPTY);// new
+    // ItemStack[NUMSLOTS];
+
+    public boolean dirty = false;
+    public EntityPlayer player;
+
+    public TGPlayerInventoryOld(EntityPlayer player) {
+        this.player = player;
+    }
+
+
+    public void saveNBTData(NBTTagCompound tags) {
+        // NBTTagList nbttaglist = new NBTTagList();
+        ItemStackHelper.saveAllItems(tags, this.inventory);
+
+        // tags.setTag(name, nbttaglist);
+    }
+    public void loadNBTData(NBTTagCompound tags) {
+        // NBTTagList nbttaglist = tags.getTagList(name, 10);
+        this.inventory.clear(); // = NonNullList.<ItemStack>withSize(NUMSLOTS, ItemStack.EMPTY);
+
+        ItemStackHelper.loadAllItems(tags, this.inventory);
+    }
+
+    @Override
+    public int getSizeInventory() {
+        return NUMSLOTS;
+    }
+
+    @Override
+    public ItemStack getStackInSlot(int slotid) {
+        return slotid >= 0 && slotid < this.inventory.size() ? this.inventory.get(slotid) : ItemStack.EMPTY;
+    }
+
+    @Override
+    public ItemStack decrStackSize(int index, int count) {
+        List<ItemStack> list = this.inventory;
+
+        return list != null && !((ItemStack) list.get(index)).isEmpty() ? ItemStackHelper.getAndSplit(list, index, count) : ItemStack.EMPTY;
+    }
+
+    @Override
+    public void setInventorySlotContents(int slotid, ItemStack itemstack) {
+        this.inventory.set(slotid, itemstack);
+
+        if(slotid == SLOT_FACE) {
+            player.getDataManager().set(TGExtendedPlayer.DATA_FACE_SLOT, itemstack);
+        } else if (slotid== SLOT_BACK) {
+            player.getDataManager().set(TGExtendedPlayer.DATA_BACK_SLOT, itemstack);
+        } else if (slotid == SLOT_HAND) {
+            player.getDataManager().set(TGExtendedPlayer.DATA_HAND_SLOT, itemstack);
+        }
+
+        this.markDirty();
+    }
+
+    @Override
+    public int getInventoryStackLimit() {
+        return 64;
+    }
+
+    @Override
+    public void markDirty() {
+        // System.out.println("Marked inv as dirty");
+        this.dirty = true;
+    }
+
+    @Override
+    public boolean isItemValidForSlot(int slotid, ItemStack itemstack) {
+        return true;
+    }
+
+    @Override
+    public String getName() {
+        return this.name;
+    }
+
+    @Override
+    public boolean hasCustomName() {
+        return false;
+    }
+
+    @Override
+    public ITextComponent getDisplayName() {
+        return new TextComponentTranslation("techguns.extendedinventory", new Object[0]);
+    }
+
+    @Override
+    public boolean isEmpty() {
+        for (ItemStack itemstack1 : this.inventory) {
+            if (!itemstack1.isEmpty()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public ItemStack removeStackFromSlot(int index) {
+        NonNullList<ItemStack> nonnulllist = this.inventory;
+        if (nonnulllist != null && !((ItemStack) nonnulllist.get(index)).isEmpty()) {
+            ItemStack itemstack = nonnulllist.get(index);
+            nonnulllist.set(index, ItemStack.EMPTY);
+            return itemstack;
+        } else {
+            return ItemStack.EMPTY;
+        }
+    }
+
+    @Override
+    public void openInventory(EntityPlayer player) {
+    }
+
+    @Override
+    public void closeInventory(EntityPlayer player) {
+    }
+
+    @Override
+    public int getField(int id) {
+        return 0;
+    }
+
+    @Override
+    public void setField(int id, int value) {
+    }
+
+    @Override
+    public int getFieldCount() {
+        return 0;
+    }
+
+    @Override
+    public void clear() {
+        this.inventory.clear();
+    }
+
+    @Override
+    public boolean isUsableByPlayer(EntityPlayer player) {
+        if (this.player.isDead) {
+            return false;
+        } else {
+            return player.getDistanceSq(this.player) <= 64.0D;
+        }
+    }
+
+}
+

--- a/src/main/java/techguns/gui/widgets/SlotFood.java
+++ b/src/main/java/techguns/gui/widgets/SlotFood.java
@@ -1,13 +1,13 @@
 package techguns.gui.widgets;
 
-import net.minecraft.inventory.IInventory;
-import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemFood;
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.items.ItemStackHandler;
+import net.minecraftforge.items.SlotItemHandler;
 
-public class SlotFood extends Slot {
+public class SlotFood extends SlotItemHandler {
 
-	public SlotFood(IInventory inv, int id, int x, int y) {
+	public SlotFood(ItemStackHandler inv, int id, int x, int y) {
 		super(inv, id, x, y);
 	}
 

--- a/src/main/java/techguns/gui/widgets/SlotTG.java
+++ b/src/main/java/techguns/gui/widgets/SlotTG.java
@@ -37,10 +37,11 @@ public class SlotTG extends SlotItemHandler {
 		if(!super.isItemValid(itemstack))
 			return false;
 
-		if (!itemstack.isEmpty() && itemstack.getItem() instanceof ITGSpecialSlot){
-			ITGSpecialSlot slot = (ITGSpecialSlot) itemstack.getItem();
-			return slot.getSlot(itemstack)==type;
+		if(itemstack.getItem() instanceof ITGSpecialSlot){
+			ITGSpecialSlot specialSlot = (ITGSpecialSlot) itemstack.getItem();
+			return specialSlot.getSlot(itemstack).equals(type);
 		}
+
 		return type.equals(TGSlotType.NORMAL);
 	}
 

--- a/src/main/java/techguns/gui/widgets/SlotTG.java
+++ b/src/main/java/techguns/gui/widgets/SlotTG.java
@@ -1,14 +1,16 @@
 package techguns.gui.widgets;
 
-import net.minecraft.inventory.IInventory;
-import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.items.ItemStackHandler;
+import net.minecraftforge.items.SlotItemHandler;
 import techguns.Techguns;
 import techguns.api.tginventory.ITGSpecialSlot;
 import techguns.api.tginventory.TGSlotType;
 
-public class SlotTG extends Slot {
+import javax.annotation.Nonnull;
+
+public class SlotTG extends SlotItemHandler {
 	private final TGSlotType type;
 	public static final ResourceLocation BACKSLOT_TEX = new ResourceLocation(Techguns.MODID,"gui/emptyslots/emptyslot_back");
 	public static final ResourceLocation FACESLOT_TEX = new ResourceLocation(Techguns.MODID,"gui/emptyslots/emptyslot_face");
@@ -25,18 +27,21 @@ public class SlotTG extends Slot {
 	public static final ResourceLocation INGOTSLOT_TEX = new ResourceLocation(Techguns.MODID,"gui/emptyslots/emptyslot_ingot");
 	public static final ResourceLocation INGOTDARKSLOT_TEX = new ResourceLocation(Techguns.MODID,"gui/emptyslots/emptyslot_ingot_dark");
 	
-	public SlotTG(IInventory inv, int index, int posx, int posy, TGSlotType type) {
+	public SlotTG(ItemStackHandler inv, int index, int posx, int posy, TGSlotType type) {
 		super(inv, index, posx, posy);
 		this.type=type;
 	}
 	
 	@Override
 	public boolean isItemValid(ItemStack itemstack) {
+		if(!super.isItemValid(itemstack))
+			return false;
+
 		if (!itemstack.isEmpty() && itemstack.getItem() instanceof ITGSpecialSlot){
 			ITGSpecialSlot slot = (ITGSpecialSlot) itemstack.getItem();
 			return slot.getSlot(itemstack)==type;
 		}
-		return TGSlotType.NORMAL==type;
+		return type.equals(TGSlotType.NORMAL);
 	}
 
 	public TGSlotType getType() {
@@ -63,6 +68,4 @@ public class SlotTG extends Slot {
 		}
 		return super.getSlotTexture();
 	}
-
-	
 }

--- a/src/main/java/techguns/items/additionalslots/ItemTGSpecialSlot.java
+++ b/src/main/java/techguns/items/additionalslots/ItemTGSpecialSlot.java
@@ -73,22 +73,22 @@ public abstract class ItemTGSpecialSlot extends GenericItem implements ITGSpecia
 		
 		if(this.getSlot(stack)==TGSlotType.BACKSLOT) {
 			TGExtendedPlayer props  = TGExtendedPlayer.get(playerIn);
-			if (props.tg_inventory.inventory.get(TGPlayerInventory.SLOT_BACK).isEmpty()){
-				props.tg_inventory.inventory.set(TGPlayerInventory.SLOT_BACK,stack.copy());
+			if (props.tg_inventory.getStackInSlot(TGPlayerInventory.SLOT_BACK).isEmpty()){
+				props.tg_inventory.setStackInSlot(TGPlayerInventory.SLOT_BACK, stack.copy());
 				stack.setCount(0);
 				return new ActionResult<ItemStack>(EnumActionResult.SUCCESS, stack);
 			}
 		} else if (this.getSlot(stack)==TGSlotType.FACESLOT){
 			TGExtendedPlayer props  = TGExtendedPlayer.get(playerIn);
-			if (props.tg_inventory.inventory.get(TGPlayerInventory.SLOT_FACE).isEmpty()){
-				props.tg_inventory.inventory.set(TGPlayerInventory.SLOT_FACE,stack.copy());
+			if (props.tg_inventory.getStackInSlot(TGPlayerInventory.SLOT_FACE).isEmpty()){
+				props.tg_inventory.setStackInSlot(TGPlayerInventory.SLOT_FACE,stack.copy());
 				stack.setCount(0);
 				return new ActionResult<ItemStack>(EnumActionResult.SUCCESS, stack);
 			}
 		} else if (this.getSlot(stack)==TGSlotType.HANDSLOT){
 			TGExtendedPlayer props  = TGExtendedPlayer.get(playerIn);
-			if (props.tg_inventory.inventory.get(TGPlayerInventory.SLOT_HAND).isEmpty()){
-				props.tg_inventory.inventory.set(TGPlayerInventory.SLOT_HAND,stack.copy());
+			if (props.tg_inventory.getStackInSlot(TGPlayerInventory.SLOT_HAND).isEmpty()){
+				props.tg_inventory.setStackInSlot(TGPlayerInventory.SLOT_HAND,stack.copy());
 				stack.setCount(0);
 				return new ActionResult<ItemStack>(EnumActionResult.SUCCESS, stack);
 			}

--- a/src/main/java/techguns/items/armors/GenericArmor.java
+++ b/src/main/java/techguns/items/armors/GenericArmor.java
@@ -327,9 +327,9 @@ public class GenericArmor extends ItemArmor implements ISpecialArmor , IItemTGRe
 		
 		if(props!=null){
 			
-			bonus+=getBonusForSlot(props.tg_inventory.inventory.get(TGPlayerInventory.SLOT_FACE), type, consumePower, ply);
-			bonus+=getBonusForSlot(props.tg_inventory.inventory.get(TGPlayerInventory.SLOT_BACK), type, consumePower, ply);
-			bonus+=getBonusForSlot(props.tg_inventory.inventory.get(TGPlayerInventory.SLOT_HAND), type, consumePower, ply);
+			bonus+=getBonusForSlot(props.tg_inventory.getStackInSlot(TGPlayerInventory.SLOT_FACE), type, consumePower, ply);
+			bonus+=getBonusForSlot(props.tg_inventory.getStackInSlot(TGPlayerInventory.SLOT_BACK), type, consumePower, ply);
+			bonus+=getBonusForSlot(props.tg_inventory.getStackInSlot(TGPlayerInventory.SLOT_HAND), type, consumePower, ply);
 		}
 		
 		return bonus;
@@ -469,9 +469,7 @@ public class GenericArmor extends ItemArmor implements ISpecialArmor , IItemTGRe
 	/**
 	 * to override in subclasses
 	 * @param item
-	 * @param player
 	 * @param list
-	 * @param b
 	 * @return
 	 */
 	protected void addMinimalInformation(ItemStack item, List<String> list){

--- a/src/main/java/techguns/tileentities/CamoBenchTileEnt.java
+++ b/src/main/java/techguns/tileentities/CamoBenchTileEnt.java
@@ -89,7 +89,7 @@ public class CamoBenchTileEnt extends BasicOwnedTileEnt {
 					boolean back = id %2==odd_even;
 					TGExtendedPlayer props = TGExtendedPlayer.get(ply);
 					if (props!=null){
-						ItemStack item = props.tg_inventory.inventory.get(TGPlayerInventory.SLOT_BACK);
+						ItemStack item = props.tg_inventory.getStackInSlot(TGPlayerInventory.SLOT_BACK);
 						if(item!=null && item.getItem() instanceof ICamoChangeable) {
 							ICamoChangeable camoitem = (ICamoChangeable) item.getItem();
 							camoitem.switchCamo(item, back);
@@ -100,7 +100,7 @@ public class CamoBenchTileEnt extends BasicOwnedTileEnt {
 					boolean back = id %2==odd_even;
 					TGExtendedPlayer props = TGExtendedPlayer.get(ply);
 					if (props!=null){
-						ItemStack item = props.tg_inventory.inventory.get(TGPlayerInventory.SLOT_FACE);
+						ItemStack item = props.tg_inventory.getStackInSlot(TGPlayerInventory.SLOT_FACE);
 						if(item!=null && item.getItem() instanceof ICamoChangeable) {
 							ICamoChangeable camoitem = (ICamoChangeable) item.getItem();
 							camoitem.switchCamo(item, back);


### PR DESCRIPTION
this commit adds optional support for OpenComputers (OC) to the Reaction Chamber

the OC cable has to be connected to the controller block (bottom or front should work) and the component can be used as `component.tg2_reactionchamber`

currently added the following methods:
```lua
setLiquidLevel(Integer:level) -- allows to set the liquid limit (valid values are 0-10)
getLiquidLevel() -- returns the current configured liquid limit

setIntensity(Integer:level) -- sets the intensity level (valid values are 0-10)
getIntensity() -- returns the intensity level

dumpLiquid() -- dumps the liquid from the input tank

getEnergyStored() -- returns the amount of energy in the energybuffer
getMaxEnergyStored() -- returns the max amount of energy in the energybuffer

getReactionStats() -- returns if the reaction is valid, if so it also returns values of progress/duration/energyusage and the currently preferred intensity
```

i've not added methods to get informations about the inventory/tank as a OC Transposer can already be used for this